### PR TITLE
Term Isn't Required Anymore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ doc=false
 
 [dependencies]
 getopts = "0.2"
+
+[dev-dependencies]
 term = "0.2.7"


### PR DESCRIPTION
There is no `extern crate term` anywhere.