### PR TITLE
create Changeset struct and implement Display on it

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,101 @@
+
+use std::fmt;
+
+use super::{Changeset, Difference};
+
+impl fmt::Display for Changeset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for d in &self.diffs {
+            match *d {
+                Difference::Same(ref x) => {
+                    try!(write!(f, "{}{}", x, self.split));
+                }
+                Difference::Add(ref x) => {
+                    try!(write!(f, "\x1b[92m{}\x1b[0m{}", x, self.split));
+                }
+                Difference::Rem(ref x) => {
+                    try!(write!(f, "\x1b[91m{}\x1b[0m{}", x, self.split));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Changeset};
+    use std::io::Write;
+    use std::iter::FromIterator;
+    use std::thread;
+    use std::time;
+
+    /// convert slice to vector for assert_eq
+    fn vb(b: &'static [u8]) -> Vec<u8> {
+        Vec::from_iter(b.iter().cloned())
+    }
+
+    /// if the format changes, you can use this to help create the test for color
+    /// just pass it in and copy-paste (validating that it looks right first of course...)
+    #[allow(dead_code)]
+    fn debug_bytes(result: &[u8], expected: &[u8]) {
+        // sleep for a bit so stderr passes us
+        thread::sleep(time::Duration::new(0, 2e8 as u32));
+        println!("Debug Result:");
+        for b in result {
+            print!("{}", *b as char);
+        }
+        println!("Repr Result:");
+        repr_bytes(result);
+        println!("");
+        println!("--Result Repr DONE");
+
+        println!("Debug Expected:");
+        for b in expected {
+            print!("{}", *b as char);
+        }
+        println!("Repr Expected:");
+        repr_bytes(expected);
+        println!("");
+        println!("--Expected Repr DONE");
+    }
+
+    /// for helping debugging what the actual bytes are
+    /// for writing user tests
+    fn repr_bytes(bytes: &[u8]) {
+        for b in bytes {
+            match *b {
+                // 9 => print!("{}", *b as char), // TAB
+                b'\n' => print!("\\n"),
+                b'\r' => print!("\\r"),
+                32...126 => print!("{}", *b as char), // visible ASCII
+                _ => print!(r"\x{:0>2x}", b),
+
+            }
+        }
+    }
+
+    #[test]
+    fn test_display() {
+        let text1 = "Roses are red, violets are blue,\n\
+                     I wrote this library,\n\
+                     just for you.\n\
+                     (It's true).";
+
+        let text2 = "Roses are red, violets are blue,\n\
+                     I wrote this documentation,\n\
+                     just for you.\n\
+                     (It's quite true).";
+        let expected = 
+            b"Roses are red, violets are blue,\n\x1b[91mI wrote this library,\x1b\
+            [0m\n\x1b[92mI wrote this documentation,\x1b[0m\njust for you.\n\x1b\
+            [91m(It's true).\x1b[0m\n\x1b[92m(It's quite true).\x1b[0m\n";
+
+        let ch = Changeset::new(text1, text2, "\n");
+        let mut result: Vec<u8> = Vec::new();
+        write!(result, "{}", ch).unwrap();
+        debug_bytes(&result, expected);
+        assert_eq!(result, vb(expected));
+
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,8 @@ fn main() {
     };
 
     if matches.free.len() > 1 {
-        difference::print_diff(&matches.free[0], &matches.free[1], split);
+        let ch = difference::Changeset::new(&matches.free[0], &matches.free[1], split);
+        println!("{}", ch);
     } else {
         print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
         return;


### PR DESCRIPTION
- add unit tests for displaying diffs

This creates a Changeset struct with a `new` method and `Display` implemented on it, with the intent to supercede `diff()` and `print_diff()` -- which would become deprecated once this is stabilized.

Having all the information as a struct has other benefits, such as that users of the lib can keep track of the settings they used when creating the changeset.