### PR TITLE
No color options, print support for windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ bin = ["getopts"]
 
 [dependencies]
 getopts = {version = "0.2", optional = true}
+term = "0.2.7"
 
 [dev-dependencies]
-term = "0.2.7"

--- a/src/display.rs
+++ b/src/display.rs
@@ -33,6 +33,7 @@ impl fmt::Display for Changeset {
 #[cfg(test)]
 mod tests {
     use super::super::Changeset;
+    use super::super::ChangesetOptions;
     use std::io::Write;
     use std::iter::FromIterator;
     use std::thread;
@@ -104,5 +105,28 @@ mod tests {
         debug_bytes(&result, expected);
         assert_eq!(result, vb(expected));
 
+    }
+
+    #[test]
+    fn test_display_with_word_diff() {
+        let text1 = "Roses are red, violets are blue,\n\
+                     I wrote this library,\n\
+                     just for you.\n\
+                     (It's true).";
+
+        let text2 = "Roses are red, violets are blue,\n\
+                     I wrote this documentation,\n\
+                     just for you.\n\
+                     (It's quite true).";
+        let expected = b"Roses are red, violets are blue,\n[-I wrote this library,-]\
+            \n[+I wrote this documentation,+]\njust for you.\n[-\
+            (It's true).-]\n[+(It's quite true).+]\n";
+
+        let ch_options = ChangesetOptions::new(true);
+        let ch = Changeset::new_with_options(text1, text2, "\n", ch_options);
+        let mut result: Vec<u8> = Vec::new();
+        write!(result, "{}", ch).unwrap();
+        debug_bytes(&result, expected);
+        assert_eq!(result, vb(expected));
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -11,10 +11,18 @@ impl fmt::Display for Changeset {
                     try!(write!(f, "{}{}", x, self.split));
                 }
                 Difference::Add(ref x) => {
-                    try!(write!(f, "\x1b[92m{}\x1b[0m{}", x, self.split));
+                    if self.word_diff {
+                        try!(write!(f, "[-{}-]{}", x, self.split));
+                    } else {
+                        try!(write!(f, "\x1b[92m{}\x1b[0m{}", x, self.split));
+                    }
                 }
                 Difference::Rem(ref x) => {
-                    try!(write!(f, "\x1b[91m{}\x1b[0m{}", x, self.split));
+                    if self.word_diff {
+                        try!(write!(f, "[+{}+]{}", x, self.split));
+                    } else {
+                        try!(write!(f, "\x1b[91m{}\x1b[0m{}", x, self.split));
+                    }
                 }
             }
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -12,14 +12,14 @@ impl fmt::Display for Changeset {
                 }
                 Difference::Add(ref x) => {
                     if self.word_diff {
-                        try!(write!(f, "[-{}-]{}", x, self.split));
+                        try!(write!(f, "[+{}+]{}", x, self.split));
                     } else {
                         try!(write!(f, "\x1b[92m{}\x1b[0m{}", x, self.split));
                     }
                 }
                 Difference::Rem(ref x) => {
                     if self.word_diff {
-                        try!(write!(f, "[+{}+]{}", x, self.split));
+                        try!(write!(f, "[-{}-]{}", x, self.split));
                     } else {
                         try!(write!(f, "\x1b[91m{}\x1b[0m{}", x, self.split));
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,10 @@ pub fn print_diff(orig: &str, edit: &str, split: &str, options: ChangesetOptions
         }
     }
     t.reset().unwrap();
-    try!(writeln!(t, "")); // W/o this - terminals will print '%'
+    if !split.contains("\n") {
+        // Include trailing line break if split doesn't include one
+        try!(writeln!(t, ""));
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,10 @@ fn main() {
         _ => " ",
     };
 
+    let changeset_options = difference::ChangesetOptions::new(false);
+
     if matches.free.len() > 1 {
-        let ch = difference::Changeset::new(&matches.free[0], &matches.free[1], split);
-        println!("{}", ch);
+        difference::print_diff(&matches.free[0], &matches.free[1], split, changeset_options).unwrap();
     } else {
         print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ fn main() {
 
     let mut opts = Options::new();
     opts.optopt("s", "split", "", "char|word|line");
+    opts.optflag("", "word-diff", "Enable word diffs instead of colored diffs");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
@@ -33,7 +34,7 @@ fn main() {
         _ => " ",
     };
 
-    let changeset_options = difference::ChangesetOptions::new(false);
+    let changeset_options = difference::ChangesetOptions::new(matches.opt_present("word-diff"));
 
     if matches.free.len() > 1 {
         difference::print_diff(&matches.free[0], &matches.free[1], split, changeset_options).unwrap();

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -82,11 +82,28 @@ pub fn merge(orig: &str, edit: &str, common: &str, split: &str) -> Vec<Differenc
 
 
 #[test]
-fn test_merge() {
+fn test_merge_char() {
     assert_eq!(merge("testa", "tost", "tst", ""),
                vec![Difference::Same("t".to_string()),
                     Difference::Rem("e".to_string()),
                     Difference::Add("o".to_string()),
                     Difference::Same("st".to_string()),
                     Difference::Rem("a".to_string())]);
+}
+
+#[test]
+fn test_merge_word() {
+    assert_eq!(merge("foo bar", "boo bar", "bar", " "),
+               vec![Difference::Same("".to_string()),
+                    Difference::Rem("foo".to_string()),
+                    Difference::Add("boo".to_string()),
+                    Difference::Same("bar".to_string())]);
+}
+
+#[test]
+fn test_merge_line() {
+    assert_eq!(merge("foo", "boo", "", "\n"),
+               vec![Difference::Same("".to_string()),
+                    Difference::Rem("foo".to_string()),
+                    Difference::Add("boo".to_string())]);
 }


### PR DESCRIPTION
This PR was made to address issues in -> https://github.com/johannhof/difference.rs/issues/15

First rust contribution so I'll preface to say if things seem messed up/wrong let me know and I'll try my best to fix them!

- Added support --word-diff flag. If that flag is set, then instead of colors, text will be used to distinguish diffs in the text. 
- Added a new 'constructor' that takes in an options object. (Just word-diff for now, but eventually this can hold a bunch of options)
- Added options struct that will hold options that difference.rs might use later
- Un deprecated print_diff. This was done because AFAIK the term module only supports stdin and stdout. So to leverage this library to support windows, I took the avenue to have a function that will print directly to stdin and stdout so other terminals are supported. 