### PR TITLE
Cleanup and fix bugs

### DIFF
--- a/src/lcs.rs
+++ b/src/lcs.rs
@@ -1,96 +1,79 @@
+use std::cmp::max;
+
+// strsplit is like `s.split(split)`, except that if `split` is "", it
+// trims the leading and trailing empty elements, since the `lcs`
+// logic won't handle those properly.
+fn strsplit<'a>(s: &'a str, split: &str) -> Vec<&'a str> {
+    let mut si = s.split(split);
+    if split == "" {
+        si.next();
+    }
+    let mut v: Vec<&str> = si.collect();
+    if split == "" {
+        v.pop();
+    }
+    v
+}
+
 // finds the longest common subsequences
 // outputs the edit distance and a string containing
 // all chars both inputs have in common
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
 pub fn lcs(orig: &str, edit: &str, split: &str) -> (i32, String) {
-
     // make list by custom splits
-    let a: Vec<&str> = orig.split(split).collect();
-    let b: Vec<&str> = edit.split(split).collect();
+    let a = strsplit(orig, split);
+    let b = strsplit(edit, split);
 
-    let N = a.len() as i32;
-    let M = b.len() as i32;
+    let N = a.len();
+    let M = b.len();
 
-    let MAX = N + M;
+    let mut idx: Vec<usize> = Vec::with_capacity(N * M);
+    idx.resize(N * M, 0);
 
-    let mut v: Vec<i32> = (-MAX..MAX).collect();
-
-    // container to hold common subsequence
-    let mut common = String::new();
-
-    v[1] = 0;
-
-    // iterate over D = "edit steps"
-    for D in 0..MAX {
-        let mut max = 0;
-        let mut max_snake: Box<String> = Box::new("".to_string());
-
-        // TODO replace with
-        // for k in (-D..D+1).step_by(2) {
-        // once it's stable
-
-        let mut k = -D;
-
-        while k < D + 1 {
-            let mut snake = String::new();
-
-            let mut x;
-
-            let index = (MAX + k - 1) as usize;
-            if k == -D || k != D && v[index - 1] < v[index + 1] {
-                x = v[index + 1];
-            } else {
-                x = v[index - 1] + 1;
-            }
-
-            let mut y = x - k;
-
-            while x < N && y < M && a[x as usize] == b[y as usize] {
-                if !snake.is_empty() {
-                    // add back the splits that were taken away
-                    snake.push_str(split);
-                }
-                snake.push_str(a[x as usize]);
-                x += 1;
-                y += 1;
-            }
-
-            v[index] = x;
-
-            if x > max {
-                max = x;
-                max_snake = Box::new(snake);
-            }
-
-            if x >= N && y >= M {
-                // add last max_snake
-                if max_snake.len() > 0 {
-                    if !common.is_empty() {
-                        // add back the splits that were taken away
-                        common.push_str(split);
-                    }
-                    common.push_str(&max_snake);
+    for i in 0..N {
+        for j in 0..M {
+            if b[j] == a[i] {
+                if i == 0 || j == 0 {
+                    idx[i * M + j] = 1;
                 } else {
-                    common.push_str(split);
+                    idx[i * M + j] = idx[(i - 1) * M + j - 1] + 1;
                 }
-                return (D, common);
+            } else if i == 0 {
+                if j == 0 {
+                    idx[i * M + j] = 0;
+                } else {
+                    idx[i * M + j] = idx[i * M + j - 1];
+                }
+            } else if j == 0 {
+                idx[i * M + j] = idx[(i - 1) * M + j];
+            } else {
+                idx[i * M + j] = max(idx[i * M + j - 1], idx[(i - 1) * M + j]);
             }
-            k += 2;
         }
-
-        if max_snake.len() > 0 {
-            if !common.is_empty() {
-                // add back the splits that were taken away
-                common.push_str(split);
-            }
-            common.push_str(&max_snake);
-        }
-
     }
 
-    // both strings don't match at all
-    (MAX, "".to_string())
+    let mut i = (N as isize) - 1;
+    let mut j = (M as isize) - 1;
+    let mut lcs = Vec::new();
+    while i >= 0 && j >= 0 {
+        let ui = i as usize;
+        let uj = j as usize;
+        if a[ui] == b[uj] {
+            lcs.push(a[ui]);
+            i -= 1;
+            j -= 1;
+        } else if j == 0 && i == 0 {
+            break;
+        } else if i == 0 || idx[ui * M + uj - 1] > idx[(ui - 1) * M + uj] {
+            j -= 1;
+        } else {
+            i -= 1;
+        }
+    }
+
+    lcs.reverse();
+    ((N + M - 2 * lcs.len()) as i32, lcs.join(split))
 }
 
 #[test]
@@ -114,7 +97,7 @@ fn test_lcs() {
             "The quick brown dog leaps over the lazy cat",
             " ",
         ),
-        (6, "The quick brown over the lazy ".to_string())
+        (6, "The quick brown over the lazy".to_string())
     );
 
     assert_eq!(
@@ -133,4 +116,13 @@ fn test_lcs() {
         ),
         (0, "The quick brown fox jumps over the lazy dog".to_string())
     );
+
+    assert_eq!(
+        lcs("a b : c", "b a : b : c", " "),
+        (2, "a b : c".to_string())
+    );
+
+    assert_eq!(lcs("", "a b c", ""), (5, "".to_string()));
+
+    assert_eq!(lcs("", " a", " "), (1, "".to_string()));
 }

--- a/src/lcs.rs
+++ b/src/lcs.rs
@@ -18,6 +18,9 @@ fn strsplit<'a>(s: &'a str, split: &str) -> Vec<&'a str> {
 // finds the longest common subsequences
 // outputs the edit distance and a string containing
 // all chars both inputs have in common
+//
+// This algorithm is based on
+// https://en.wikipedia.org/wiki/Longest_common_subsequence_problem#Code_for_the_dynamic_programming_solution
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
 pub fn lcs(orig: &str, edit: &str, split: &str) -> (i32, String) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,94 @@ fn test_diff() {
 }
 
 #[test]
+fn test_diff_brief() {
+    let text1 = "Hello\nworld";
+    let text2 = "Ola\nmundo";
+
+    let changeset = Changeset::new(text1, text2, "\n");
+
+    assert_eq!(
+        changeset.diffs,
+        vec![
+            Difference::Rem("Hello\nworld".to_string()),
+            Difference::Add("Ola\nmundo".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_diff_smaller_line_count_on_left() {
+    let text1 = "Hello\nworld";
+    let text2 = "Ola\nworld\nHow is it\ngoing?";
+
+    let changeset = Changeset::new(text1, text2, "\n");
+
+    assert_eq!(
+        changeset.diffs,
+        vec![
+            Difference::Rem("Hello".to_string()),
+            Difference::Add("Ola".to_string()),
+            Difference::Same("world".to_string()),
+            Difference::Add("How is it\ngoing?".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_diff_smaller_line_count_on_right() {
+    let text1 = "Hello\nworld\nWhat a \nbeautiful\nday!";
+    let text2 = "Ola\nworld";
+
+    let changeset = Changeset::new(text1, text2, "\n");
+
+    assert_eq!(
+        changeset.diffs,
+        vec![
+            Difference::Rem("Hello".to_string()),
+            Difference::Add("Ola".to_string()),
+            Difference::Same("world".to_string()),
+            Difference::Rem("What a \nbeautiful\nday!".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_diff_similar_text_with_smaller_line_count_on_right() {
+    let text1 = "Hello\nworld\nWhat a \nbeautiful\nday!";
+    let text2 = "Hello\nwoRLd";
+
+    let changeset = Changeset::new(text1, text2, "\n");
+
+    assert_eq!(
+        changeset.diffs,
+        vec![
+            Difference::Same("Hello".to_string()),
+            Difference::Rem("world\nWhat a \nbeautiful\nday!".to_string()),
+            Difference::Add("woRLd".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_diff_similar_text_with_similar_line_count() {
+    let text1 = "Hello\nworld\nWhat a \nbeautiful\nday!";
+    let text2 = "Hello\nwoRLd\nbeautiful";
+
+    let changeset = Changeset::new(text1, text2, "\n");
+
+    assert_eq!(
+        changeset.diffs,
+        vec![
+            Difference::Same("Hello".to_string()),
+            Difference::Rem("world\nWhat a ".to_string()),
+            Difference::Add("woRLd".to_string()),
+            Difference::Same("beautiful".to_string()),
+            Difference::Rem("day!".to_string()),
+        ]
+    );
+}
+
+#[test]
 #[should_panic]
 fn test_assert_diff_panic() {
     let text1 = "Roses are red, violets are blue,\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 
+#[cfg(feature = "bin")]
 extern crate difference;
 #[cfg(feature = "bin")]
 extern crate getopts;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -4,77 +4,50 @@ use Difference;
 pub fn merge(orig: &str, edit: &str, common: &str, split: &str) -> Vec<Difference> {
     let mut ret = Vec::new();
 
-    let mut a = orig.split(split);
-    let mut b = edit.split(split);
+    let mut l = orig.split(split).peekable();
+    let mut r = edit.split(split).peekable();
+    let mut c = common.split(split).peekable();
 
-    let mut same = String::new();
-    for c in common.split(split) {
-        let mut add = String::new();
-        let mut rem = String::new();
+    // Turn empty strings into [], not [""]
+    if orig == "" {
+        l.next();
+    }
+    if edit == "" {
+        r.next();
+    }
+    if common == "" {
+        c.next();
+    }
 
-        let mut x = a.next();
-        while x != None && Some(c) != x {
-            if !rem.is_empty() {
-                rem.push_str(split);
-            }
-            rem.push_str(x.unwrap());
-            x = a.next();
+    while l.peek().is_some() || r.peek().is_some() {
+        let mut same = Vec::new();
+        while l.peek().is_some() && l.peek() == c.peek() && r.peek() == c.peek() {
+            same.push(l.next().unwrap());
+            r.next();
+            c.next();
         }
-
-        let mut y = b.next();
-        while y != None && Some(c) != y {
-            if !add.is_empty() {
-                add.push_str(split);
-            }
-            add.push_str(y.unwrap());
-            y = b.next();
-        }
-
-        if !add.is_empty() || !rem.is_empty() {
-            ret.push(Difference::Same(same.clone()));
-            same.clear();
-        }
-
-        if !rem.is_empty() {
-            ret.push(Difference::Rem(rem.clone()));
-        }
-
-        if !add.is_empty() {
-            ret.push(Difference::Add(add.clone()));
-        }
-
         if !same.is_empty() {
-            same.push_str(split);
+            let joined = same.join(split);
+            if split != "" || joined != "" {
+                ret.push(Difference::Same(joined));
+            }
         }
-        same.push_str(c);
-    }
-    if !same.is_empty() {
-        ret.push(Difference::Same(same.clone()));
-    }
 
-    // TODO avoid duplication
-
-    let mut rem = String::new();
-
-    for x in a {
+        let mut rem = Vec::new();
+        while l.peek().is_some() && l.peek() != c.peek() {
+            rem.push(l.next().unwrap());
+        }
         if !rem.is_empty() {
-            rem.push_str(split);
+            ret.push(Difference::Rem(rem.join(split)));
         }
-        rem.push_str(x);
-    }
-    if !rem.is_empty() {
-        ret.push(Difference::Rem(rem.clone()));
-    }
 
-    let mut add = String::new();
-    for y in b {
-        if !add.is_empty() {
-            add.push_str(split);
+        let mut add = Vec::new();
+        while r.peek().is_some() && r.peek() != c.peek() {
+            add.push(r.next().unwrap());
         }
-        add.push_str(y);
-    }
-    if !add.is_empty() {
-        ret.push(Difference::Add(add.clone()));
+        if !add.is_empty() {
+            ret.push(Difference::Add(add.join(split)));
+        }
     }
 
     ret
@@ -91,6 +64,29 @@ fn test_merge() {
             Difference::Add("o".to_string()),
             Difference::Same("st".to_string()),
             Difference::Rem("a".to_string()),
+        ]
+    );
+
+    assert_eq!(
+        merge("", "a", "", ""),
+        vec![Difference::Add("a".to_string())]
+    );
+
+    assert_eq!(
+        merge("a\nb", "a\n\nb", "a\nb", "\n"),
+        vec![
+            Difference::Same("a".to_string()),
+            Difference::Add("".to_string()),
+            Difference::Same("b".to_string()),
+        ]
+    );
+
+    assert_eq!(
+        merge("a\n", "c\n", "\n", "\n"),
+        vec![
+            Difference::Rem("a".to_string()),
+            Difference::Add("c".to_string()),
+            Difference::Same("".to_string()),
         ]
     );
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -94,15 +94,12 @@ fn simple() {
 }
 
 #[test]
-#[ignore]
 fn issue_19() {
-    // this should work but it doesn't
     // https://github.com/johannhof/difference.rs/issues/19
     quickcheck(check_changeset("a b : g", "b a : b b : g g", " "));
 }
 
 #[test]
-#[ignore]
 fn fuzzy() {
     fn prop(old: Vec<usize>, new: Vec<usize>, words: Vec<char>) -> TestResult {
         if words.is_empty() {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -100,6 +100,7 @@ fn issue_19() {
 }
 
 #[test]
+#[allow(needless_pass_by_value)]
 fn fuzzy() {
     fn prop(old: Vec<usize>, new: Vec<usize>, words: Vec<char>) -> TestResult {
         if words.is_empty() {
@@ -126,6 +127,6 @@ fn fuzzy() {
 
     QuickCheck::new()
         .tests(100) // max successful tests
-        .max_tests(10000) // max attempts
+        .max_tests(10_000) // max attempts
         .quickcheck(prop as fn(Vec<usize>, Vec<usize>, Vec<char>) -> TestResult);
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -50,21 +50,8 @@ impl<'a> Check<'a> {
     fn check(&self) -> TestResult {
         let split = &self.changeset.split;
 
-        let mut old = self.old.trim_left_matches(split);
-        let mut new = self.new.trim_left_matches(split);
-
-        macro_rules! expect {
-            ($ident:ident, $pattern:expr, $diff:expr, $split:expr) => {
-                if !$ident.starts_with($pattern) {
-                    return TestResult::error(format!("`{:?}` does not match `{}` at {:?} for {}",
-                                                      $diff,
-                                                      stringify!($ident),
-                                                      $ident,
-                                                      self));
-                }
-                $ident = &$ident[$pattern.len()..].trim_left_matches($split);
-            }
-        }
+        let mut old: Vec<&str> = Vec::new();
+        let mut new: Vec<&str> = Vec::new();
 
         for d in &self.changeset.diffs {
             if DEBUG {
@@ -73,31 +60,30 @@ impl<'a> Check<'a> {
 
             match *d {
                 Difference::Same(ref x) => {
-                    expect!(old, x, d, split);
-                    expect!(new, x, d, split);
+                    old.push(x);
+                    new.push(x);
                 }
                 Difference::Add(ref x) => {
-                    expect!(new, x, d, split);
+                    new.push(x);
                 }
                 Difference::Rem(ref x) => {
-                    expect!(old, x, d, split);
+                    old.push(x);
                 }
             }
         }
-        if !old.is_empty() {
-            return TestResult::error(format!(
-                "expected end of string in `old` at {:?} for {}",
-                old,
-                self
-            ));
+        let got_old = old.join(split);
+        let got_new = new.join(split);
+        if got_old != self.old {
+            return TestResult::error(format!("Diff output implies old=`{:?}`, not `{:?}` in {}",
+                        got_old, self.old, self,
+                ));
         }
-        if !new.is_empty() {
-            return TestResult::error(format!(
-                "expected end of string in `new` at {:?} for {}",
-                new,
-                self
-            ));
+        if got_new != self.new {
+            return TestResult::error(format!("Diff output implies new=`{:?}`, not `{:?}` in {}",
+                        got_new, self.new, self,
+                ));
         }
+
         TestResult::passed()
     }
 }


### PR DESCRIPTION
This branch substantially rewrites `lcs` and `merge` to be shorter and simpler, and in the process fixes a number of bugs:

- fixes #19 (bug was in `lcs`)
- fixed #17 (this bug was in `merge`)
- fixed #21 (was revealing bugs in all three of `lcs`, `merge`, and `check_changeset`)

Sorry for the invasive PR, but this was the best way I could find to fix these bugs.