### PR TITLE
Make `rustfmt` happy again.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 format_strings = false
 reorder_imports = true
-
+error_on_line_overflow = false


### PR DESCRIPTION
Allow single-line comments to overflow rustfmt width.

We have a long URL that we can't otherwise include.

n.b. that the travis nightly build is still broken due to https://github.com/rust-lang-nursery/rust-clippy/issues/2184 ; once that PR lands it should go green again. I'm not sure if there's anything to be done in the interim.