### PR TITLE
Implement more traits on `Difference` and `Changeset` (Clone, Hash, Eq)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ bin = ["getopts"]
 getopts = {version = "0.2", optional = true}
 
 [dev-dependencies]
-term = "0.5"
-quickcheck = "0.6"
+term = "0.7"
+quickcheck = "1.0"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,3 @@
-
-
 use super::{Changeset, Difference};
 use std::fmt;
 
@@ -7,15 +5,9 @@ impl fmt::Display for Changeset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for d in &self.diffs {
             match *d {
-                Difference::Same(ref x) => {
-                    try!(write!(f, "{}{}", x, self.split));
-                }
-                Difference::Add(ref x) => {
-                    try!(write!(f, "\x1b[92m{}\x1b[0m{}", x, self.split));
-                }
-                Difference::Rem(ref x) => {
-                    try!(write!(f, "\x1b[91m{}\x1b[0m{}", x, self.split));
-                }
+                Difference::Same(ref x) => write!(f, "{}{}", x, self.split)?,
+                Difference::Add(ref x) => write!(f, "\x1b[92m{}\x1b[0m{}", x, self.split)?,
+                Difference::Rem(ref x) => write!(f, "\x1b[91m{}\x1b[0m{}", x, self.split)?,
             }
         }
         Ok(())
@@ -47,7 +39,7 @@ mod tests {
         }
         println!("Repr Result:");
         repr_bytes(result);
-        println!("");
+        println!();
         println!("--Result Repr DONE");
 
         println!("Debug Expected:");
@@ -56,7 +48,7 @@ mod tests {
         }
         println!("Repr Expected:");
         repr_bytes(expected);
-        println!("");
+        println!();
         println!("--Expected Repr DONE");
     }
 
@@ -68,9 +60,8 @@ mod tests {
                 // 9 => print!("{}", *b as char), // TAB
                 b'\n' => print!("\\n"),
                 b'\r' => print!("\\r"),
-                32...126 => print!("{}", *b as char), // visible ASCII
+                32..=126 => print!("{}", *b as char), // visible ASCII
                 _ => print!(r"\x{:0>2x}", b),
-
             }
         }
     }
@@ -95,6 +86,5 @@ mod tests {
         write!(result, "{}", ch).unwrap();
         debug_bytes(&result, expected);
         assert_eq!(result, vb(expected));
-
     }
 }

--- a/src/lcs.rs
+++ b/src/lcs.rs
@@ -5,11 +5,11 @@ use std::cmp::max;
 // logic won't handle those properly.
 fn strsplit<'a>(s: &'a str, split: &str) -> Vec<&'a str> {
     let mut si = s.split(split);
-    if split == "" {
+    if split.is_empty() {
         si.next();
     }
     let mut v: Vec<&str> = si.collect();
-    if split == "" {
+    if split.is_empty() {
         v.pop();
     }
     v
@@ -21,8 +21,7 @@ fn strsplit<'a>(s: &'a str, split: &str) -> Vec<&'a str> {
 //
 // This algorithm is based on
 // https://en.wikipedia.org/wiki/Longest_common_subsequence_problem#Code_for_the_dynamic_programming_solution
-#[allow(non_snake_case)]
-#[cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
+#[allow(non_snake_case, clippy::many_single_char_names)]
 pub fn lcs(orig: &str, edit: &str, split: &str) -> (i32, String) {
     // make list by custom splits
     let a = strsplit(orig, split);
@@ -31,8 +30,7 @@ pub fn lcs(orig: &str, edit: &str, split: &str) -> (i32, String) {
     let N = a.len();
     let M = b.len();
 
-    let mut idx: Vec<usize> = Vec::with_capacity(N * M);
-    idx.resize(N * M, 0);
+    let mut idx: Vec<usize> = vec![0; N * M];
 
     for i in 0..N {
         for j in 0..M {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,9 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
+mod display;
 mod lcs;
 mod merge;
-mod display;
 
 use lcs::lcs;
 use merge::merge;
@@ -48,7 +48,7 @@ use merge::merge;
 /// Defines the contents of a changeset
 /// Changesets will be delivered in order of appearance in the original string
 /// Sequences of the same kind will be grouped into one Difference
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum Difference {
     /// Sequences that are the same
     Same(String),
@@ -59,6 +59,7 @@ pub enum Difference {
 }
 
 /// The information about a full changeset
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Changeset {
     /// An ordered vector of `Difference` objects, coresponding
     /// to the differences within the text
@@ -157,21 +158,23 @@ pub fn diff(orig: &str, edit: &str, split: &str) -> (i32, Vec<Difference>) {
 /// Will print an error with a colorful diff in case of failure.
 #[macro_export]
 macro_rules! assert_diff {
-    ($orig:expr , $edit:expr, $split: expr, $expected: expr) => ({
+    ($orig:expr , $edit:expr, $split: expr, $expected: expr) => {{
         let orig = $orig;
         let edit = $edit;
 
         let changeset = $crate::Changeset::new(orig, edit, &($split));
         if changeset.distance != $expected {
             println!("{}", changeset);
-            panic!("assertion failed: edit distance between {:?} and {:?} is {} and not {}, see \
+            panic!(
+                "assertion failed: edit distance between {:?} and {:?} is {} and not {}, see \
                     diffset above",
-                   orig,
-                   edit,
-                   changeset.distance,
-                   &($expected))
+                orig,
+                edit,
+                changeset.distance,
+                &($expected)
+            )
         }
-    })
+    }};
 }
 
 /// **This function is deprecated, `Changeset` now implements the `Display` trait instead**
@@ -187,7 +190,10 @@ macro_rules! assert_diff {
 /// use difference::print_diff;
 /// print_diff("Diffs are awesome", "Diffs are cool", " ");
 /// ```
-#[deprecated(since = "1.0.0", note = "`Changeset` now implements the `Display` trait instead")]
+#[deprecated(
+    since = "1.0.0",
+    note = "`Changeset` now implements the `Display` trait instead"
+)]
 pub fn print_diff(orig: &str, edit: &str, split: &str) {
     let ch = Changeset::new(orig, edit, split);
     println!("{}", ch);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     opts.optopt("s", "split", "", "char|word|line");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => panic!(f.to_string()),
+        Err(f) => panic!("{}", f),
     };
 
     let split = match matches.opt_str("s") {
@@ -41,6 +41,4 @@ fn main() {
         print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
         return;
     };
-
-
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -9,13 +9,13 @@ pub fn merge(orig: &str, edit: &str, common: &str, split: &str) -> Vec<Differenc
     let mut c = common.split(split).peekable();
 
     // Turn empty strings into [], not [""]
-    if orig == "" {
+    if orig.is_empty() {
         l.next();
     }
-    if edit == "" {
+    if edit.is_empty() {
         r.next();
     }
-    if common == "" {
+    if common.is_empty() {
         c.next();
     }
 
@@ -28,7 +28,7 @@ pub fn merge(orig: &str, edit: &str, common: &str, split: &str) -> Vec<Differenc
         }
         if !same.is_empty() {
             let joined = same.join(split);
-            if split != "" || joined != "" {
+            if !split.is_empty() || !joined.is_empty() {
                 ret.push(Difference::Same(joined));
             }
         }
@@ -52,7 +52,6 @@ pub fn merge(orig: &str, edit: &str, common: &str, split: &str) -> Vec<Differenc
 
     ret
 }
-
 
 #[test]
 fn test_merge() {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -2,7 +2,7 @@ extern crate difference;
 extern crate quickcheck;
 
 use difference::{Changeset, Difference};
-use quickcheck::{TestResult, quickcheck, QuickCheck};
+use quickcheck::{quickcheck, QuickCheck, TestResult};
 use std::fmt;
 
 const DEBUG: bool = false;
@@ -18,9 +18,7 @@ impl<'a> fmt::Display for Check<'a> {
         write!(
             f,
             "Changeset::new({:?}, {:?}, {:?}) -> [",
-            self.old,
-            self.new,
-            self.changeset.split
+            self.old, self.new, self.changeset.split
         )?;
 
         let mut iter = self.changeset.diffs.iter();
@@ -74,14 +72,16 @@ impl<'a> Check<'a> {
         let got_old = old.join(split);
         let got_new = new.join(split);
         if got_old != self.old {
-            return TestResult::error(format!("Diff output implies old=`{:?}`, not `{:?}` in {}",
-                        got_old, self.old, self,
-                ));
+            return TestResult::error(format!(
+                "Diff output implies old=`{:?}`, not `{:?}` in {}",
+                got_old, self.old, self,
+            ));
         }
         if got_new != self.new {
-            return TestResult::error(format!("Diff output implies new=`{:?}`, not `{:?}` in {}",
-                        got_new, self.new, self,
-                ));
+            return TestResult::error(format!(
+                "Diff output implies new=`{:?}`, not `{:?}` in {}",
+                got_new, self.new, self,
+            ));
         }
 
         TestResult::passed()
@@ -100,7 +100,7 @@ fn issue_19() {
 }
 
 #[test]
-#[allow(needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value)]
 fn fuzzy() {
     fn prop(old: Vec<usize>, new: Vec<usize>, words: Vec<char>) -> TestResult {
         if words.is_empty() {
@@ -108,16 +108,16 @@ fn fuzzy() {
         }
 
         fn map_to_words(input: &[usize], words: &[char]) -> String {
-            input.iter().enumerate().fold(
-                String::new(),
-                |mut acc, (i, x)| {
+            input
+                .iter()
+                .enumerate()
+                .fold(String::new(), |mut acc, (i, x)| {
                     if i > 0 {
                         acc.push(' ');
                     }
                     acc.push(words[x % words.len()]);
                     acc
-                },
-            )
+                })
         }
         let old = map_to_words(&old, &words);
         let new = map_to_words(&new, &words);


### PR DESCRIPTION
To suit more use cases, I've added derives for traits including `Clone`, `Eq` and `Hash` on `Difference` and `Changeset`. This allows library users to clone instances of these types, as well as putting them in structs deriving `Clone` or `HashMap`s.

In order to do this and still make the tests pass, I've done a bit of maintenance work. The crate denies warnings, but still uses deprecated syntax like `try!()` and `...`, creating compile warnings. I've also fixed some clippy lints applied improperly. (It appears that some of this was also done in other unmerged PRs)